### PR TITLE
Improve onboarding defaults and clean Ctrl+C shutdown

### DIFF
--- a/run-slack-channel.sh
+++ b/run-slack-channel.sh
@@ -72,10 +72,77 @@ printf 'TRIGGER_MODE: %s\n' "$trigger_mode"
 printf 'Press Ctrl+C to stop.\n'
 printf '=== END ===\n'
 
-# Secrets stay as env vars — everything else comes from appsettings.json
-exec env \
-	NetClaw__Channels__Slack__Enabled=true \
-	NetClaw__Channels__Slack__BotToken="$SLACK_BOT_TOKEN" \
-	NetClaw__Channels__Slack__AppToken="$SLACK_APP_TOKEN" \
-	"$DOTNET_BIN" run --project "$SCRIPT_DIR/src/FireLakeLabs.NetClaw.Host" "$@"
+# Repeated Ctrl+C can kill `dotnet run` before it tears down child processes; we explicitly stop descendants.
+run_host_with_cleanup() {
+	local host_pid=0
+	local interrupted=0
+
+	kill_descendants() {
+		local parent_pid="$1"
+		local signal="$2"
+		local child_pid
+
+		if ! command -v pgrep >/dev/null 2>&1; then
+			return
+		fi
+
+		while IFS= read -r child_pid; do
+			if [[ -z "$child_pid" ]]; then
+				continue
+			fi
+
+			kill_descendants "$child_pid" "$signal"
+			kill "-$signal" "$child_pid" 2>/dev/null || true
+		done < <(pgrep -P "$parent_pid" || true)
+	}
+
+	stop_host() {
+		local signal="$1"
+
+		if [[ "$host_pid" -le 0 ]]; then
+			return
+		fi
+
+		if ! kill -0 "$host_pid" 2>/dev/null; then
+			return
+		fi
+
+		kill_descendants "$host_pid" "$signal"
+		kill "-$signal" "$host_pid" 2>/dev/null || true
+	}
+
+	on_interrupt() {
+		if [[ "$interrupted" -eq 0 ]]; then
+			interrupted=1
+			echo "Stopping NetClaw host..."
+			stop_host TERM
+		else
+			echo "Force-stopping NetClaw host and children..."
+			stop_host KILL
+		fi
+	}
+
+	trap on_interrupt INT
+	trap 'stop_host TERM' TERM
+	trap 'stop_host TERM' EXIT
+
+	# Secrets stay as env vars — everything else comes from appsettings.json
+	env \
+		NetClaw__Channels__Slack__Enabled=true \
+		NetClaw__Channels__Slack__BotToken="$SLACK_BOT_TOKEN" \
+		NetClaw__Channels__Slack__AppToken="$SLACK_APP_TOKEN" \
+		"$DOTNET_BIN" run --project "$SCRIPT_DIR/src/FireLakeLabs.NetClaw.Host" "$@" &
+	host_pid=$!
+
+	set +e
+	wait "$host_pid"
+	local exit_code=$?
+	set -e
+
+	trap - INT TERM EXIT
+	return "$exit_code"
+}
+
+run_host_with_cleanup "$@"
+
 	

--- a/run-slack-channel.sh
+++ b/run-slack-channel.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/scripts/host-cleanup.sh"
 DOTNET_BIN="${DOTNET_BIN:-}"
 
 if [[ -z "$DOTNET_BIN" ]]; then
@@ -72,77 +73,18 @@ printf 'TRIGGER_MODE: %s\n' "$trigger_mode"
 printf 'Press Ctrl+C to stop.\n'
 printf '=== END ===\n'
 
-# Repeated Ctrl+C can kill `dotnet run` before it tears down child processes; we explicitly stop descendants.
-run_host_with_cleanup() {
-	local host_pid=0
-	local interrupted=0
+host_command=(
+	env
+	NetClaw__Channels__Slack__Enabled=true
+	NetClaw__Channels__Slack__BotToken="$SLACK_BOT_TOKEN"
+	NetClaw__Channels__Slack__AppToken="$SLACK_APP_TOKEN"
+	"$DOTNET_BIN"
+	run
+	--project
+	"$SCRIPT_DIR/src/FireLakeLabs.NetClaw.Host"
+)
+host_command+=("$@")
 
-	kill_descendants() {
-		local parent_pid="$1"
-		local signal="$2"
-		local child_pid
-
-		if ! command -v pgrep >/dev/null 2>&1; then
-			return
-		fi
-
-		while IFS= read -r child_pid; do
-			if [[ -z "$child_pid" ]]; then
-				continue
-			fi
-
-			kill_descendants "$child_pid" "$signal"
-			kill "-$signal" "$child_pid" 2>/dev/null || true
-		done < <(pgrep -P "$parent_pid" || true)
-	}
-
-	stop_host() {
-		local signal="$1"
-
-		if [[ "$host_pid" -le 0 ]]; then
-			return
-		fi
-
-		if ! kill -0 "$host_pid" 2>/dev/null; then
-			return
-		fi
-
-		kill_descendants "$host_pid" "$signal"
-		kill "-$signal" "$host_pid" 2>/dev/null || true
-	}
-
-	on_interrupt() {
-		if [[ "$interrupted" -eq 0 ]]; then
-			interrupted=1
-			echo "Stopping NetClaw host..."
-			stop_host TERM
-		else
-			echo "Force-stopping NetClaw host and children..."
-			stop_host KILL
-		fi
-	}
-
-	trap on_interrupt INT
-	trap 'stop_host TERM' TERM
-	trap 'stop_host TERM' EXIT
-
-	# Secrets stay as env vars — everything else comes from appsettings.json
-	env \
-		NetClaw__Channels__Slack__Enabled=true \
-		NetClaw__Channels__Slack__BotToken="$SLACK_BOT_TOKEN" \
-		NetClaw__Channels__Slack__AppToken="$SLACK_APP_TOKEN" \
-		"$DOTNET_BIN" run --project "$SCRIPT_DIR/src/FireLakeLabs.NetClaw.Host" "$@" &
-	host_pid=$!
-
-	set +e
-	wait "$host_pid"
-	local exit_code=$?
-	set -e
-
-	trap - INT TERM EXIT
-	return "$exit_code"
-}
-
-run_host_with_cleanup "$@"
+run_host_with_cleanup "${host_command[@]}"
 
 	

--- a/run-terminal-channel.sh
+++ b/run-terminal-channel.sh
@@ -3,6 +3,18 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DOTNET_BIN="${DOTNET_BIN:-}"
+
+if [[ -z "$DOTNET_BIN" ]]; then
+	if command -v dotnet >/dev/null 2>&1; then
+		DOTNET_BIN="$(command -v dotnet)"
+	elif [[ -x "$HOME/.dotnet/dotnet" ]]; then
+		DOTNET_BIN="$HOME/.dotnet/dotnet"
+	else
+		echo "Unable to locate dotnet. Set DOTNET_BIN or add dotnet to PATH." >&2
+		exit 1
+	fi
+fi
 
 PROJECT_ROOT="${NETCLAW_PROJECT_ROOT:-$HOME/.netclaw}"
 CHAT_JID="${NETCLAW_CHAT_JID:-team@jid}"
@@ -14,10 +26,10 @@ REQUIRE_TRIGGER="${NETCLAW_REQUIRE_TRIGGER:-false}"
 export NETCLAW_PROJECT_ROOT="$PROJECT_ROOT"
 
 # Initialize project directory and config if needed
-dotnet run --project "$SCRIPT_DIR/src/FireLakeLabs.NetClaw.Setup" -- --step init
+"$DOTNET_BIN" run --project "$SCRIPT_DIR/src/FireLakeLabs.NetClaw.Setup" -- --step init
 
 register_args=(
-	dotnet run --project "$SCRIPT_DIR/src/FireLakeLabs.NetClaw.Setup" -- --step register
+	"$DOTNET_BIN" run --project "$SCRIPT_DIR/src/FireLakeLabs.NetClaw.Setup" -- --step register
 	--jid "$CHAT_JID"
 	--name "$CHAT_NAME"
 	--trigger "$AGENT_TRIGGER"
@@ -45,7 +57,74 @@ printf 'EXAMPLE: %s\n' "$example_prompt"
 printf 'Press Ctrl+C to stop.\n'
 printf '=== END ===\n'
 
-exec env \
-	NetClaw__Channels__Terminal__Enabled=true \
-	dotnet run --project "$SCRIPT_DIR/src/FireLakeLabs.NetClaw.Host" "$@"
+# Repeated Ctrl+C can kill `dotnet run` before it tears down child processes; we explicitly stop descendants.
+run_host_with_cleanup() {
+	local host_pid=0
+	local interrupted=0
+
+	kill_descendants() {
+		local parent_pid="$1"
+		local signal="$2"
+		local child_pid
+
+		if ! command -v pgrep >/dev/null 2>&1; then
+			return
+		fi
+
+		while IFS= read -r child_pid; do
+			if [[ -z "$child_pid" ]]; then
+				continue
+			fi
+
+			kill_descendants "$child_pid" "$signal"
+			kill "-$signal" "$child_pid" 2>/dev/null || true
+		done < <(pgrep -P "$parent_pid" || true)
+	}
+
+	stop_host() {
+		local signal="$1"
+
+		if [[ "$host_pid" -le 0 ]]; then
+			return
+		fi
+
+		if ! kill -0 "$host_pid" 2>/dev/null; then
+			return
+		fi
+
+		kill_descendants "$host_pid" "$signal"
+		kill "-$signal" "$host_pid" 2>/dev/null || true
+	}
+
+	on_interrupt() {
+		if [[ "$interrupted" -eq 0 ]]; then
+			interrupted=1
+			echo "Stopping NetClaw host..."
+			stop_host TERM
+		else
+			echo "Force-stopping NetClaw host and children..."
+			stop_host KILL
+		fi
+	}
+
+	trap on_interrupt INT
+	trap 'stop_host TERM' TERM
+	trap 'stop_host TERM' EXIT
+
+	env \
+		NetClaw__Channels__Terminal__Enabled=true \
+		"$DOTNET_BIN" run --project "$SCRIPT_DIR/src/FireLakeLabs.NetClaw.Host" "$@" &
+	host_pid=$!
+
+	set +e
+	wait "$host_pid"
+	local exit_code=$?
+	set -e
+
+	trap - INT TERM EXIT
+	return "$exit_code"
+}
+
+run_host_with_cleanup "$@"
+
 	

--- a/run-terminal-channel.sh
+++ b/run-terminal-channel.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/scripts/host-cleanup.sh"
 DOTNET_BIN="${DOTNET_BIN:-}"
 
 if [[ -z "$DOTNET_BIN" ]]; then
@@ -57,74 +58,16 @@ printf 'EXAMPLE: %s\n' "$example_prompt"
 printf 'Press Ctrl+C to stop.\n'
 printf '=== END ===\n'
 
-# Repeated Ctrl+C can kill `dotnet run` before it tears down child processes; we explicitly stop descendants.
-run_host_with_cleanup() {
-	local host_pid=0
-	local interrupted=0
+host_command=(
+	env
+	NetClaw__Channels__Terminal__Enabled=true
+	"$DOTNET_BIN"
+	run
+	--project
+	"$SCRIPT_DIR/src/FireLakeLabs.NetClaw.Host"
+)
+host_command+=("$@")
 
-	kill_descendants() {
-		local parent_pid="$1"
-		local signal="$2"
-		local child_pid
-
-		if ! command -v pgrep >/dev/null 2>&1; then
-			return
-		fi
-
-		while IFS= read -r child_pid; do
-			if [[ -z "$child_pid" ]]; then
-				continue
-			fi
-
-			kill_descendants "$child_pid" "$signal"
-			kill "-$signal" "$child_pid" 2>/dev/null || true
-		done < <(pgrep -P "$parent_pid" || true)
-	}
-
-	stop_host() {
-		local signal="$1"
-
-		if [[ "$host_pid" -le 0 ]]; then
-			return
-		fi
-
-		if ! kill -0 "$host_pid" 2>/dev/null; then
-			return
-		fi
-
-		kill_descendants "$host_pid" "$signal"
-		kill "-$signal" "$host_pid" 2>/dev/null || true
-	}
-
-	on_interrupt() {
-		if [[ "$interrupted" -eq 0 ]]; then
-			interrupted=1
-			echo "Stopping NetClaw host..."
-			stop_host TERM
-		else
-			echo "Force-stopping NetClaw host and children..."
-			stop_host KILL
-		fi
-	}
-
-	trap on_interrupt INT
-	trap 'stop_host TERM' TERM
-	trap 'stop_host TERM' EXIT
-
-	env \
-		NetClaw__Channels__Terminal__Enabled=true \
-		"$DOTNET_BIN" run --project "$SCRIPT_DIR/src/FireLakeLabs.NetClaw.Host" "$@" &
-	host_pid=$!
-
-	set +e
-	wait "$host_pid"
-	local exit_code=$?
-	set -e
-
-	trap - INT TERM EXIT
-	return "$exit_code"
-}
-
-run_host_with_cleanup "$@"
+run_host_with_cleanup "${host_command[@]}"
 
 	

--- a/scripts/host-cleanup.sh
+++ b/scripts/host-cleanup.sh
@@ -4,6 +4,7 @@ run_host_with_cleanup() {
 	local host_pid=0
 	local host_pgid=""
 	local new_session=0
+	local shell_pgid=""
 	local interrupted=0
 
 	kill_descendants() {
@@ -29,6 +30,11 @@ run_host_with_cleanup() {
 		local signal="$1"
 
 		if [[ "$new_session" -eq 0 ]] || [[ -z "$host_pgid" ]]; then
+			return
+		fi
+
+		# Defensive guard in case PGIDs still match for any reason.
+		if [[ -n "$shell_pgid" && "$host_pgid" == "$shell_pgid" ]]; then
 			return
 		fi
 
@@ -67,6 +73,7 @@ run_host_with_cleanup() {
 	trap on_interrupt INT
 	trap 'stop_host TERM' TERM
 	trap 'stop_host TERM' EXIT
+	shell_pgid="$(ps -o pgid= -p "$$" | tr -d ' ' || true)"
 
 	if command -v setsid >/dev/null 2>&1; then
 		setsid "$@" &

--- a/scripts/host-cleanup.sh
+++ b/scripts/host-cleanup.sh
@@ -3,6 +3,7 @@
 run_host_with_cleanup() {
 	local host_pid=0
 	local host_pgid=""
+	local new_session=0
 	local interrupted=0
 
 	kill_descendants() {
@@ -27,7 +28,7 @@ run_host_with_cleanup() {
 	signal_process_group() {
 		local signal="$1"
 
-		if [[ -z "$host_pgid" ]]; then
+		if [[ "$new_session" -eq 0 ]] || [[ -z "$host_pgid" ]]; then
 			return
 		fi
 
@@ -69,6 +70,7 @@ run_host_with_cleanup() {
 
 	if command -v setsid >/dev/null 2>&1; then
 		setsid "$@" &
+		new_session=1
 	else
 		"$@" &
 	fi
@@ -77,8 +79,18 @@ run_host_with_cleanup() {
 	host_pgid="$(ps -o pgid= -p "$host_pid" | tr -d ' ' || true)"
 
 	set +e
-	wait "$host_pid"
-	local exit_code=$?
+	local exit_code
+	while :; do
+		wait "$host_pid"
+		exit_code=$?
+
+		# If wait was interrupted by SIGINT (130) but the host is still alive,
+		# keep waiting so that a second Ctrl+C can escalate to KILL and we
+		# don't return before the process group is actually gone.
+		if [[ "$exit_code" -ne 130 ]] || ! kill -0 "$host_pid" 2>/dev/null; then
+			break
+		fi
+	done
 	set -e
 
 	trap - INT TERM EXIT

--- a/scripts/host-cleanup.sh
+++ b/scripts/host-cleanup.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+run_host_with_cleanup() {
+	local host_pid=0
+	local host_pgid=""
+	local interrupted=0
+
+	kill_descendants() {
+		local parent_pid="$1"
+		local signal="$2"
+		local child_pid
+
+		if ! command -v pgrep >/dev/null 2>&1; then
+			return
+		fi
+
+		while IFS= read -r child_pid; do
+			if [[ -z "$child_pid" ]]; then
+				continue
+			fi
+
+			kill_descendants "$child_pid" "$signal"
+			kill "-$signal" "$child_pid" 2>/dev/null || true
+		done < <(pgrep -P "$parent_pid" || true)
+	}
+
+	signal_process_group() {
+		local signal="$1"
+
+		if [[ -z "$host_pgid" ]]; then
+			return
+		fi
+
+		kill "-$signal" -- "-$host_pgid" 2>/dev/null || true
+	}
+
+	fallback_descendant_cleanup() {
+		local signal="$1"
+
+		if [[ "$host_pid" -le 0 ]]; then
+			return
+		fi
+
+		kill_descendants "$host_pid" "$signal"
+		kill "-$signal" "$host_pid" 2>/dev/null || true
+	}
+
+	stop_host() {
+		local signal="$1"
+
+		signal_process_group "$signal"
+		fallback_descendant_cleanup "$signal"
+	}
+
+	on_interrupt() {
+		if [[ "$interrupted" -eq 0 ]]; then
+			interrupted=1
+			echo "Stopping NetClaw host..."
+			stop_host TERM
+		else
+			echo "Force-stopping NetClaw host and children..."
+			stop_host KILL
+		fi
+	}
+
+	trap on_interrupt INT
+	trap 'stop_host TERM' TERM
+	trap 'stop_host TERM' EXIT
+
+	if command -v setsid >/dev/null 2>&1; then
+		setsid "$@" &
+	else
+		"$@" &
+	fi
+
+	host_pid=$!
+	host_pgid="$(ps -o pgid= -p "$host_pid" | tr -d ' ' || true)"
+
+	set +e
+	wait "$host_pid"
+	local exit_code=$?
+	set -e
+
+	trap - INT TERM EXIT
+	return "$exit_code"
+}

--- a/src/FireLakeLabs.NetClaw.Infrastructure/Runtime/Agents/NetClawAgentWorkspaceBuilder.cs
+++ b/src/FireLakeLabs.NetClaw.Infrastructure/Runtime/Agents/NetClawAgentWorkspaceBuilder.cs
@@ -59,6 +59,15 @@ If BOOTSTRAP.md exists, follow it first.
 - Daily notes: memory/YYYY-MM-DD.md
 - Long-term: MEMORY.md
 
+## When Given No Task
+
+If the user says things like "you tell me", "up to you", or gives no concrete task:
+
+1. Read MEMORY.md and the most recent daily note if they exist.
+2. Summarize active or recently touched work.
+3. Propose 1-3 concrete next actions with a brief reason for each.
+4. Start with the most useful option unless the user chooses differently.
+
 ## Safety
 
 - Don't exfiltrate private data.


### PR DESCRIPTION
- [x] Harden launcher shutdown with process groups (44d5877)
- [x] Fix: only use PGID kill path when host was started in a new session via setsid
- [x] Fix: loop on `wait` so SIGINT interruption (exit 130) doesn't cause early return while host is still alive

<!-- START COPILOT CODING AGENT TIPS -->
---

⌨️ Start Copilot coding agent tasks without leaving your editor — available in [VS Code](https://gh.io/cca-vs-code-docs), [Visual Studio](https://gh.io/cca-visual-studio-docs), [JetBrains IDEs](https://gh.io/cca-jetbrains-docs) and [Eclipse](https://gh.io/cca-eclipse-docs).
