### PR TITLE
Follow-up: enforce onboarding guidance and stronger Ctrl+C cleanup

### DIFF
--- a/config-examples/appsettings.example.json
+++ b/config-examples/appsettings.example.json
@@ -27,7 +27,7 @@
       "CopilotAutoRestart": true,
       "CopilotUseLoggedInUser": false,
       "CopilotClientName": "NetClaw",
-      "CopilotModel": "gpt-5",
+      "CopilotModel": "claude-opus-4.6",
       "InteractiveIdleTimeout": "00:00:30",
       "CopilotReasoningEffort": "high",
       "CopilotStreaming": true,

--- a/run-slack-channel.sh
+++ b/run-slack-channel.sh
@@ -42,12 +42,13 @@ if [[ -z "$SLACK_APP_TOKEN" ]]; then
 fi
 
 export NETCLAW_PROJECT_ROOT="$PROJECT_ROOT"
+export NETCLAW_HOST_PROCESS_MATCH="FireLakeLabs.NetClaw.Host"
 
 # Initialize project directory and config if needed
-"$DOTNET_BIN" run --project "$SCRIPT_DIR/src/FireLakeLabs.NetClaw.Setup" -- --step init
+"$DOTNET_BIN" run --disable-build-servers --project "$SCRIPT_DIR/src/FireLakeLabs.NetClaw.Setup" -- --step init
 
 register_args=(
-	"$DOTNET_BIN" run --project "$SCRIPT_DIR/src/FireLakeLabs.NetClaw.Setup" -- --step register
+	"$DOTNET_BIN" run --disable-build-servers --project "$SCRIPT_DIR/src/FireLakeLabs.NetClaw.Setup" -- --step register
 	--jid "$CHAT_JID"
 	--name "$CHAT_NAME"
 	--trigger "$AGENT_TRIGGER"
@@ -80,6 +81,7 @@ host_command=(
 	NetClaw__Channels__Slack__AppToken="$SLACK_APP_TOKEN"
 	"$DOTNET_BIN"
 	run
+	--disable-build-servers
 	--project
 	"$SCRIPT_DIR/src/FireLakeLabs.NetClaw.Host"
 )

--- a/run-slack-channel.sh
+++ b/run-slack-channel.sh
@@ -72,10 +72,77 @@ printf 'TRIGGER_MODE: %s\n' "$trigger_mode"
 printf 'Press Ctrl+C to stop.\n'
 printf '=== END ===\n'
 
-# Secrets stay as env vars — everything else comes from appsettings.json
-exec env \
-	NetClaw__Channels__Slack__Enabled=true \
-	NetClaw__Channels__Slack__BotToken="$SLACK_BOT_TOKEN" \
-	NetClaw__Channels__Slack__AppToken="$SLACK_APP_TOKEN" \
-	"$DOTNET_BIN" run --project "$SCRIPT_DIR/src/FireLakeLabs.NetClaw.Host" "$@"
+# Repeated Ctrl+C can kill `dotnet run` before it tears down child processes; we explicitly stop descendants.
+run_host_with_cleanup() {
+	local host_pid=0
+	local interrupted=0
+
+	kill_descendants() {
+		local parent_pid="$1"
+		local signal="$2"
+		local child_pid
+
+		if ! command -v pgrep >/dev/null 2>&1; then
+			return
+		fi
+
+		while IFS= read -r child_pid; do
+			if [[ -z "$child_pid" ]]; then
+				continue
+			fi
+
+			kill_descendants "$child_pid" "$signal"
+			kill "-$signal" "$child_pid" 2>/dev/null || true
+		done < <(pgrep -P "$parent_pid" || true)
+	}
+
+	stop_host() {
+		local signal="$1"
+
+		if [[ "$host_pid" -le 0 ]]; then
+			return
+		fi
+
+		if ! kill -0 "$host_pid" 2>/dev/null; then
+			return
+		fi
+
+		kill_descendants "$host_pid" "$signal"
+		kill "-$signal" "$host_pid" 2>/dev/null || true
+	}
+
+	on_interrupt() {
+		if [[ "$interrupted" -eq 0 ]]; then
+			interrupted=1
+			echo "Stopping NetClaw host..."
+			stop_host TERM
+		else
+			echo "Force-stopping NetClaw host and children..."
+			stop_host KILL
+		fi
+	}
+
+	trap on_interrupt INT
+	trap 'stop_host TERM' TERM
+	trap 'stop_host TERM' EXIT
+
+	# Secrets stay as env vars — everything else comes from appsettings.json
+	env \
+		NetClaw__Channels__Slack__Enabled=true \
+		NetClaw__Channels__Slack__BotToken="$SLACK_BOT_TOKEN" \
+		NetClaw__Channels__Slack__AppToken="$SLACK_APP_TOKEN" \
+		"$DOTNET_BIN" run --project "$SCRIPT_DIR/src/FireLakeLabs.NetClaw.Host" "$@" &
+	host_pid=$!
+
+	set +e
+	wait "$host_pid"
+	local exit_code=$?
+	set -e
+
+	trap - INT TERM EXIT
+	return "$exit_code"
+}
+
+run_host_with_cleanup "$@"
+
 	

--- a/run-slack-channel.sh
+++ b/run-slack-channel.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/scripts/host-cleanup.sh"
 DOTNET_BIN="${DOTNET_BIN:-}"
 
 if [[ -z "$DOTNET_BIN" ]]; then
@@ -72,77 +73,18 @@ printf 'TRIGGER_MODE: %s\n' "$trigger_mode"
 printf 'Press Ctrl+C to stop.\n'
 printf '=== END ===\n'
 
-# Repeated Ctrl+C can kill `dotnet run` before it tears down child processes; we explicitly stop descendants.
-run_host_with_cleanup() {
-	local host_pid=0
-	local interrupted=0
+host_command=(
+	env
+	NetClaw__Channels__Slack__Enabled=true
+	NetClaw__Channels__Slack__BotToken="$SLACK_BOT_TOKEN"
+	NetClaw__Channels__Slack__AppToken="$SLACK_APP_TOKEN"
+	"$DOTNET_BIN"
+	run
+	--project
+	"$SCRIPT_DIR/src/FireLakeLabs.NetClaw.Host"
+)
+host_command+=("$@")
 
-	kill_descendants() {
-		local parent_pid="$1"
-		local signal="$2"
-		local child_pid
-
-		if ! command -v pgrep >/dev/null 2>&1; then
-			return
-		fi
-
-		while IFS= read -r child_pid; do
-			if [[ -z "$child_pid" ]]; then
-				continue
-			fi
-
-			kill_descendants "$child_pid" "$signal"
-			kill "-$signal" "$child_pid" 2>/dev/null || true
-		done < <(pgrep -P "$parent_pid" || true)
-	}
-
-	stop_host() {
-		local signal="$1"
-
-		if [[ "$host_pid" -le 0 ]]; then
-			return
-		fi
-
-		if ! kill -0 "$host_pid" 2>/dev/null; then
-			return
-		fi
-
-		kill_descendants "$host_pid" "$signal"
-		kill "-$signal" "$host_pid" 2>/dev/null || true
-	}
-
-	on_interrupt() {
-		if [[ "$interrupted" -eq 0 ]]; then
-			interrupted=1
-			echo "Stopping NetClaw host..."
-			stop_host TERM
-		else
-			echo "Force-stopping NetClaw host and children..."
-			stop_host KILL
-		fi
-	}
-
-	trap on_interrupt INT
-	trap 'stop_host TERM' TERM
-	trap 'stop_host TERM' EXIT
-
-	# Secrets stay as env vars — everything else comes from appsettings.json
-	env \
-		NetClaw__Channels__Slack__Enabled=true \
-		NetClaw__Channels__Slack__BotToken="$SLACK_BOT_TOKEN" \
-		NetClaw__Channels__Slack__AppToken="$SLACK_APP_TOKEN" \
-		"$DOTNET_BIN" run --project "$SCRIPT_DIR/src/FireLakeLabs.NetClaw.Host" "$@" &
-	host_pid=$!
-
-	set +e
-	wait "$host_pid"
-	local exit_code=$?
-	set -e
-
-	trap - INT TERM EXIT
-	return "$exit_code"
-}
-
-run_host_with_cleanup "$@"
+run_host_with_cleanup "${host_command[@]}"
 
 	

--- a/run-terminal-channel.sh
+++ b/run-terminal-channel.sh
@@ -25,12 +25,13 @@ AGENT_TRIGGER="${NETCLAW_AGENT_TRIGGER:-@assistant}"
 REQUIRE_TRIGGER="${NETCLAW_REQUIRE_TRIGGER:-false}"
 
 export NETCLAW_PROJECT_ROOT="$PROJECT_ROOT"
+export NETCLAW_HOST_PROCESS_MATCH="FireLakeLabs.NetClaw.Host"
 
 # Initialize project directory and config if needed
-"$DOTNET_BIN" run --project "$SCRIPT_DIR/src/FireLakeLabs.NetClaw.Setup" -- --step init
+"$DOTNET_BIN" run --disable-build-servers --project "$SCRIPT_DIR/src/FireLakeLabs.NetClaw.Setup" -- --step init
 
 register_args=(
-	"$DOTNET_BIN" run --project "$SCRIPT_DIR/src/FireLakeLabs.NetClaw.Setup" -- --step register
+	"$DOTNET_BIN" run --disable-build-servers --project "$SCRIPT_DIR/src/FireLakeLabs.NetClaw.Setup" -- --step register
 	--jid "$CHAT_JID"
 	--name "$CHAT_NAME"
 	--trigger "$AGENT_TRIGGER"
@@ -63,6 +64,7 @@ host_command=(
 	NetClaw__Channels__Terminal__Enabled=true
 	"$DOTNET_BIN"
 	run
+	--disable-build-servers
 	--project
 	"$SCRIPT_DIR/src/FireLakeLabs.NetClaw.Host"
 )

--- a/run-terminal-channel.sh
+++ b/run-terminal-channel.sh
@@ -3,6 +3,18 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DOTNET_BIN="${DOTNET_BIN:-}"
+
+if [[ -z "$DOTNET_BIN" ]]; then
+	if command -v dotnet >/dev/null 2>&1; then
+		DOTNET_BIN="$(command -v dotnet)"
+	elif [[ -x "$HOME/.dotnet/dotnet" ]]; then
+		DOTNET_BIN="$HOME/.dotnet/dotnet"
+	else
+		echo "Unable to locate dotnet. Set DOTNET_BIN or add dotnet to PATH." >&2
+		exit 1
+	fi
+fi
 
 PROJECT_ROOT="${NETCLAW_PROJECT_ROOT:-$HOME/.netclaw}"
 CHAT_JID="${NETCLAW_CHAT_JID:-team@jid}"
@@ -14,10 +26,10 @@ REQUIRE_TRIGGER="${NETCLAW_REQUIRE_TRIGGER:-false}"
 export NETCLAW_PROJECT_ROOT="$PROJECT_ROOT"
 
 # Initialize project directory and config if needed
-dotnet run --project "$SCRIPT_DIR/src/FireLakeLabs.NetClaw.Setup" -- --step init
+"$DOTNET_BIN" run --project "$SCRIPT_DIR/src/FireLakeLabs.NetClaw.Setup" -- --step init
 
 register_args=(
-	dotnet run --project "$SCRIPT_DIR/src/FireLakeLabs.NetClaw.Setup" -- --step register
+	"$DOTNET_BIN" run --project "$SCRIPT_DIR/src/FireLakeLabs.NetClaw.Setup" -- --step register
 	--jid "$CHAT_JID"
 	--name "$CHAT_NAME"
 	--trigger "$AGENT_TRIGGER"
@@ -45,7 +57,74 @@ printf 'EXAMPLE: %s\n' "$example_prompt"
 printf 'Press Ctrl+C to stop.\n'
 printf '=== END ===\n'
 
-exec env \
-	NetClaw__Channels__Terminal__Enabled=true \
-	dotnet run --project "$SCRIPT_DIR/src/FireLakeLabs.NetClaw.Host" "$@"
+# Repeated Ctrl+C can kill `dotnet run` before it tears down child processes; we explicitly stop descendants.
+run_host_with_cleanup() {
+	local host_pid=0
+	local interrupted=0
+
+	kill_descendants() {
+		local parent_pid="$1"
+		local signal="$2"
+		local child_pid
+
+		if ! command -v pgrep >/dev/null 2>&1; then
+			return
+		fi
+
+		while IFS= read -r child_pid; do
+			if [[ -z "$child_pid" ]]; then
+				continue
+			fi
+
+			kill_descendants "$child_pid" "$signal"
+			kill "-$signal" "$child_pid" 2>/dev/null || true
+		done < <(pgrep -P "$parent_pid" || true)
+	}
+
+	stop_host() {
+		local signal="$1"
+
+		if [[ "$host_pid" -le 0 ]]; then
+			return
+		fi
+
+		if ! kill -0 "$host_pid" 2>/dev/null; then
+			return
+		fi
+
+		kill_descendants "$host_pid" "$signal"
+		kill "-$signal" "$host_pid" 2>/dev/null || true
+	}
+
+	on_interrupt() {
+		if [[ "$interrupted" -eq 0 ]]; then
+			interrupted=1
+			echo "Stopping NetClaw host..."
+			stop_host TERM
+		else
+			echo "Force-stopping NetClaw host and children..."
+			stop_host KILL
+		fi
+	}
+
+	trap on_interrupt INT
+	trap 'stop_host TERM' TERM
+	trap 'stop_host TERM' EXIT
+
+	env \
+		NetClaw__Channels__Terminal__Enabled=true \
+		"$DOTNET_BIN" run --project "$SCRIPT_DIR/src/FireLakeLabs.NetClaw.Host" "$@" &
+	host_pid=$!
+
+	set +e
+	wait "$host_pid"
+	local exit_code=$?
+	set -e
+
+	trap - INT TERM EXIT
+	return "$exit_code"
+}
+
+run_host_with_cleanup "$@"
+
 	

--- a/run-terminal-channel.sh
+++ b/run-terminal-channel.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/scripts/host-cleanup.sh"
 DOTNET_BIN="${DOTNET_BIN:-}"
 
 if [[ -z "$DOTNET_BIN" ]]; then
@@ -57,74 +58,16 @@ printf 'EXAMPLE: %s\n' "$example_prompt"
 printf 'Press Ctrl+C to stop.\n'
 printf '=== END ===\n'
 
-# Repeated Ctrl+C can kill `dotnet run` before it tears down child processes; we explicitly stop descendants.
-run_host_with_cleanup() {
-	local host_pid=0
-	local interrupted=0
+host_command=(
+	env
+	NetClaw__Channels__Terminal__Enabled=true
+	"$DOTNET_BIN"
+	run
+	--project
+	"$SCRIPT_DIR/src/FireLakeLabs.NetClaw.Host"
+)
+host_command+=("$@")
 
-	kill_descendants() {
-		local parent_pid="$1"
-		local signal="$2"
-		local child_pid
-
-		if ! command -v pgrep >/dev/null 2>&1; then
-			return
-		fi
-
-		while IFS= read -r child_pid; do
-			if [[ -z "$child_pid" ]]; then
-				continue
-			fi
-
-			kill_descendants "$child_pid" "$signal"
-			kill "-$signal" "$child_pid" 2>/dev/null || true
-		done < <(pgrep -P "$parent_pid" || true)
-	}
-
-	stop_host() {
-		local signal="$1"
-
-		if [[ "$host_pid" -le 0 ]]; then
-			return
-		fi
-
-		if ! kill -0 "$host_pid" 2>/dev/null; then
-			return
-		fi
-
-		kill_descendants "$host_pid" "$signal"
-		kill "-$signal" "$host_pid" 2>/dev/null || true
-	}
-
-	on_interrupt() {
-		if [[ "$interrupted" -eq 0 ]]; then
-			interrupted=1
-			echo "Stopping NetClaw host..."
-			stop_host TERM
-		else
-			echo "Force-stopping NetClaw host and children..."
-			stop_host KILL
-		fi
-	}
-
-	trap on_interrupt INT
-	trap 'stop_host TERM' TERM
-	trap 'stop_host TERM' EXIT
-
-	env \
-		NetClaw__Channels__Terminal__Enabled=true \
-		"$DOTNET_BIN" run --project "$SCRIPT_DIR/src/FireLakeLabs.NetClaw.Host" "$@" &
-	host_pid=$!
-
-	set +e
-	wait "$host_pid"
-	local exit_code=$?
-	set -e
-
-	trap - INT TERM EXIT
-	return "$exit_code"
-}
-
-run_host_with_cleanup "$@"
+run_host_with_cleanup "${host_command[@]}"
 
 	

--- a/scripts/host-cleanup.sh
+++ b/scripts/host-cleanup.sh
@@ -4,6 +4,7 @@ run_host_with_cleanup() {
 	local host_pid=0
 	local host_pgid=""
 	local new_session=0
+	local shell_pgid=""
 	local interrupted=0
 
 	kill_descendants() {
@@ -29,6 +30,11 @@ run_host_with_cleanup() {
 		local signal="$1"
 
 		if [[ "$new_session" -eq 0 ]] || [[ -z "$host_pgid" ]]; then
+			return
+		fi
+
+		# Defensive guard in case PGIDs still match for any reason.
+		if [[ -n "$shell_pgid" && "$host_pgid" == "$shell_pgid" ]]; then
 			return
 		fi
 
@@ -67,6 +73,7 @@ run_host_with_cleanup() {
 	trap on_interrupt INT
 	trap 'stop_host TERM' TERM
 	trap 'stop_host TERM' EXIT
+	shell_pgid="$(ps -o pgid= -p "$$" | tr -d ' ' || true)"
 
 	if command -v setsid >/dev/null 2>&1; then
 		setsid "$@" &

--- a/scripts/host-cleanup.sh
+++ b/scripts/host-cleanup.sh
@@ -6,6 +6,7 @@ run_host_with_cleanup() {
 	local new_session=0
 	local shell_pgid=""
 	local interrupted=0
+	local process_match="${NETCLAW_HOST_PROCESS_MATCH:-}"
 
 	kill_descendants() {
 		local parent_pid="$1"
@@ -52,11 +53,38 @@ run_host_with_cleanup() {
 		kill "-$signal" "$host_pid" 2>/dev/null || true
 	}
 
+	kill_matching_orphans() {
+		local signal="$1"
+		local pid
+
+		if [[ -z "$process_match" ]]; then
+			return
+		fi
+
+		if ! command -v pgrep >/dev/null 2>&1; then
+			return
+		fi
+
+		while IFS= read -r pid; do
+			if [[ -z "$pid" ]]; then
+				continue
+			fi
+
+			# Never target the launcher shell itself.
+			if [[ "$pid" == "$$" ]]; then
+				continue
+			fi
+
+			kill "-$signal" "$pid" 2>/dev/null || true
+		done < <(pgrep -f "$process_match" || true)
+	}
+
 	stop_host() {
 		local signal="$1"
 
 		signal_process_group "$signal"
 		fallback_descendant_cleanup "$signal"
+		kill_matching_orphans "$signal"
 	}
 
 	on_interrupt() {

--- a/scripts/host-cleanup.sh
+++ b/scripts/host-cleanup.sh
@@ -3,6 +3,7 @@
 run_host_with_cleanup() {
 	local host_pid=0
 	local host_pgid=""
+	local new_session=0
 	local interrupted=0
 
 	kill_descendants() {
@@ -27,7 +28,7 @@ run_host_with_cleanup() {
 	signal_process_group() {
 		local signal="$1"
 
-		if [[ -z "$host_pgid" ]]; then
+		if [[ "$new_session" -eq 0 ]] || [[ -z "$host_pgid" ]]; then
 			return
 		fi
 
@@ -69,6 +70,7 @@ run_host_with_cleanup() {
 
 	if command -v setsid >/dev/null 2>&1; then
 		setsid "$@" &
+		new_session=1
 	else
 		"$@" &
 	fi
@@ -77,8 +79,18 @@ run_host_with_cleanup() {
 	host_pgid="$(ps -o pgid= -p "$host_pid" | tr -d ' ' || true)"
 
 	set +e
-	wait "$host_pid"
-	local exit_code=$?
+	local exit_code
+	while :; do
+		wait "$host_pid"
+		exit_code=$?
+
+		# If wait was interrupted by SIGINT (130) but the host is still alive,
+		# keep waiting so that a second Ctrl+C can escalate to KILL and we
+		# don't return before the process group is actually gone.
+		if [[ "$exit_code" -ne 130 ]] || ! kill -0 "$host_pid" 2>/dev/null; then
+			break
+		fi
+	done
 	set -e
 
 	trap - INT TERM EXIT

--- a/scripts/host-cleanup.sh
+++ b/scripts/host-cleanup.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+run_host_with_cleanup() {
+	local host_pid=0
+	local host_pgid=""
+	local interrupted=0
+
+	kill_descendants() {
+		local parent_pid="$1"
+		local signal="$2"
+		local child_pid
+
+		if ! command -v pgrep >/dev/null 2>&1; then
+			return
+		fi
+
+		while IFS= read -r child_pid; do
+			if [[ -z "$child_pid" ]]; then
+				continue
+			fi
+
+			kill_descendants "$child_pid" "$signal"
+			kill "-$signal" "$child_pid" 2>/dev/null || true
+		done < <(pgrep -P "$parent_pid" || true)
+	}
+
+	signal_process_group() {
+		local signal="$1"
+
+		if [[ -z "$host_pgid" ]]; then
+			return
+		fi
+
+		kill "-$signal" -- "-$host_pgid" 2>/dev/null || true
+	}
+
+	fallback_descendant_cleanup() {
+		local signal="$1"
+
+		if [[ "$host_pid" -le 0 ]]; then
+			return
+		fi
+
+		kill_descendants "$host_pid" "$signal"
+		kill "-$signal" "$host_pid" 2>/dev/null || true
+	}
+
+	stop_host() {
+		local signal="$1"
+
+		signal_process_group "$signal"
+		fallback_descendant_cleanup "$signal"
+	}
+
+	on_interrupt() {
+		if [[ "$interrupted" -eq 0 ]]; then
+			interrupted=1
+			echo "Stopping NetClaw host..."
+			stop_host TERM
+		else
+			echo "Force-stopping NetClaw host and children..."
+			stop_host KILL
+		fi
+	}
+
+	trap on_interrupt INT
+	trap 'stop_host TERM' TERM
+	trap 'stop_host TERM' EXIT
+
+	if command -v setsid >/dev/null 2>&1; then
+		setsid "$@" &
+	else
+		"$@" &
+	fi
+
+	host_pid=$!
+	host_pgid="$(ps -o pgid= -p "$host_pid" | tr -d ' ' || true)"
+
+	set +e
+	wait "$host_pid"
+	local exit_code=$?
+	set -e
+
+	trap - INT TERM EXIT
+	return "$exit_code"
+}

--- a/src/FireLakeLabs.NetClaw.Host/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/FireLakeLabs.NetClaw.Host/DependencyInjection/ServiceCollectionExtensions.cs
@@ -312,7 +312,7 @@ public static class ServiceCollectionExtensions
                 ? useLoggedInUser
                 : null,
             CopilotClientName = configuration["NetClaw:AgentRuntime:CopilotClientName"] ?? "NetClaw",
-            CopilotModel = configuration["NetClaw:AgentRuntime:CopilotModel"] ?? "gpt-5",
+            CopilotModel = configuration["NetClaw:AgentRuntime:CopilotModel"] ?? "claude-opus-4.6",
             InteractiveIdleTimeout = TimeSpan.TryParse(configuration["NetClaw:AgentRuntime:InteractiveIdleTimeout"], out TimeSpan interactiveIdleTimeout)
                 ? interactiveIdleTimeout
                 : TimeSpan.FromSeconds(30),

--- a/src/FireLakeLabs.NetClaw.Infrastructure/Configuration/AgentRuntimeOptions.cs
+++ b/src/FireLakeLabs.NetClaw.Infrastructure/Configuration/AgentRuntimeOptions.cs
@@ -28,7 +28,7 @@ public sealed record AgentRuntimeOptions
 
     public string CopilotClientName { get; init; } = "NetClaw";
 
-    public string CopilotModel { get; init; } = "gpt-5";
+    public string CopilotModel { get; init; } = "claude-opus-4.6";
 
     public TimeSpan InteractiveIdleTimeout { get; init; } = TimeSpan.FromSeconds(30);
 

--- a/src/FireLakeLabs.NetClaw.Infrastructure/Runtime/Agents/NetClawAgentWorkspaceBuilder.cs
+++ b/src/FireLakeLabs.NetClaw.Infrastructure/Runtime/Agents/NetClawAgentWorkspaceBuilder.cs
@@ -52,7 +52,7 @@ This workspace is home. Treat it that way.
 
 ## First Run
 
-If BOOTSTRAP.md exists, follow it first.
+If BOOTSTRAP.md exists, follow it first. This overrides normal greeting and task flow.
 
 ## Memory
 
@@ -80,6 +80,17 @@ If the user gives no concrete task (for example: "you tell me"), do not default 
 Read MEMORY.md and the most recent daily note if present, summarize active work, and propose 1-3 concrete next actions with a brief reason for each.
 
 Then begin with the most useful option unless the user chooses differently.
+""";
+
+    private const string CoreBootstrapPolicy = """
+Bootstrap mode is mandatory when BOOTSTRAP.md is present.
+
+If BOOTSTRAP.md exists in the injected documents:
+
+1. Do onboarding first, before normal help/task handling.
+2. Treat greetings or small talk as the start of onboarding, not as a generic chat turn.
+3. Ask for missing identity details, write updates to IDENTITY.md/USER.md/SOUL.md as directed by BOOTSTRAP.md, then delete BOOTSTRAP.md.
+4. Do not postpone bootstrap work unless the user explicitly asks to skip it.
 """;
 
     private readonly AssistantIdentityOptions assistantIdentityOptions;
@@ -149,6 +160,15 @@ Then begin with the most useful option unless the user chooses differently.
 
         if (sessionScope != SessionScope.Subagent)
         {
+            if (fileSystem.FileExists(Path.Combine(sourceWorkspaceDirectory, "BOOTSTRAP.md")))
+            {
+                parts.Add(new InstructionPart(
+                    "NETCLAW_BOOTSTRAP_POLICY.md",
+                    WrapWithHeader("NETCLAW_BOOTSTRAP_POLICY.md", CoreBootstrapPolicy),
+                    isGenerated: true,
+                    IsCore: true));
+            }
+
             await TryAddExistingFileAsync(parts, sourceWorkspaceDirectory, "BOOTSTRAP.md", BootstrapMaxChars, cancellationToken);
         }
 

--- a/src/FireLakeLabs.NetClaw.Infrastructure/Runtime/Agents/NetClawAgentWorkspaceBuilder.cs
+++ b/src/FireLakeLabs.NetClaw.Infrastructure/Runtime/Agents/NetClawAgentWorkspaceBuilder.cs
@@ -74,6 +74,14 @@ If the user says things like "you tell me", "up to you", or gives no concrete ta
 - Don't run destructive commands without asking.
 """;
 
+    private const string CoreOnboarding = """
+If the user gives no concrete task (for example: "you tell me"), do not default to a generic intro.
+
+Read MEMORY.md and the most recent daily note if present, summarize active work, and propose 1-3 concrete next actions with a brief reason for each.
+
+Then begin with the most useful option unless the user chooses differently.
+""";
+
     private readonly AssistantIdentityOptions assistantIdentityOptions;
     private readonly IFileSystem fileSystem;
     private readonly GroupPathResolver groupPathResolver;
@@ -130,6 +138,12 @@ If the user says things like "you tell me", "up to you", or gives no concrete ta
             WrapWithHeader(
                 "NETCLAW_IDENTITY_PREAMBLE.md",
                 $"You are {identityName}, a personal assistant running in the NetClaw platform. The following documents define your personality, context, and operational guidelines."),
+            isGenerated: true,
+            IsCore: true));
+
+        parts.Add(new InstructionPart(
+            "NETCLAW_ONBOARDING.md",
+            WrapWithHeader("NETCLAW_ONBOARDING.md", CoreOnboarding),
             isGenerated: true,
             IsCore: true));
 

--- a/src/FireLakeLabs.NetClaw.Infrastructure/Runtime/Agents/NetClawAgentWorkspaceBuilder.cs
+++ b/src/FireLakeLabs.NetClaw.Infrastructure/Runtime/Agents/NetClawAgentWorkspaceBuilder.cs
@@ -59,6 +59,15 @@ If BOOTSTRAP.md exists, follow it first.
 - Daily notes: memory/YYYY-MM-DD.md
 - Long-term: MEMORY.md
 
+## When Given No Task
+
+If the user says things like "you tell me", "up to you", or gives no concrete task:
+
+1. Read MEMORY.md and the most recent daily note if they exist.
+2. Summarize active or recently touched work.
+3. Propose 1-3 concrete next actions with a brief reason for each.
+4. Start with the most useful option unless the user chooses differently.
+
 ## Safety
 
 - Don't exfiltrate private data.

--- a/src/FireLakeLabs.NetClaw.Setup/SetupRunner.cs
+++ b/src/FireLakeLabs.NetClaw.Setup/SetupRunner.cs
@@ -93,6 +93,7 @@ This workspace is home. Treat it that way.
 ## First Run
 
 If BOOTSTRAP.md exists, follow it. Complete onboarding and delete BOOTSTRAP.md.
+This overrides normal greeting and task flow.
 
 ## Memory
 
@@ -150,6 +151,11 @@ Use this as a practical cheat sheet.
 *You just woke up. Time to figure out who you are.*
 
 There is no memory yet. This is a fresh workspace.
+
+This onboarding flow is mandatory while this file exists.
+
+If the user starts with a greeting or small talk, treat that as the start of onboarding.
+Do not switch to generic help-mode until onboarding is complete.
 
 ## The Conversation
 
@@ -275,7 +281,7 @@ Delete this file.
                   "DefaultProvider": "copilot",
                   "KeepContainerBoundary": true,
                   "CopilotUseLoggedInUser": false,
-                  "CopilotModel": "gpt-5",
+                  "CopilotModel": "claude-opus-4.6",
                   "CopilotReasoningEffort": "high",
                   "CopilotStreaming": true
                 },


### PR DESCRIPTION
## Summary
- add a core generated onboarding instruction (`NETCLAW_ONBOARDING.md`) so proactive "no-task" behavior applies even when older workspace `AGENTS.md` files already exist
- harden shutdown cleanup by adding targeted orphan kill fallback (`NETCLAW_HOST_PROCESS_MATCH`) in `scripts/host-cleanup.sh`
- add `--disable-build-servers` to launcher `dotnet run` invocations to reduce lingering MSBuild server processes after interrupted runs

## Why
- screenshot evidence shows old first-message behavior still appears for existing workspaces because defaults alone are not enough
- screenshot evidence also shows post-Ctrl+C `dotnet` leftovers; process-group cleanup needed an extra fallback for reparented processes and less build-server churn

## Validation
- `bash -n scripts/host-cleanup.sh`
- `bash -n run-terminal-channel.sh`
- `bash -n run-slack-channel.sh`
- `dotnet format FireLakeLabs.NetClaw.slnx --verify-no-changes --no-restore`
- `dotnet test tests/FireLakeLabs.NetClaw.Infrastructure.Tests/FireLakeLabs.NetClaw.Infrastructure.Tests.csproj --filter "WorkspaceBuilder"`
